### PR TITLE
fix: error finally() is not a function

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -56,10 +56,14 @@ const dataHandler = (messageSet, topic, partition) => Promise.each(messageSet, (
         throw new Error(`Invalid topic: ${topic}`)
     }
   })()
-  // commit offset regardless of errors
-    .then(() => {})
-    .catch((err) => { logger.logFullError(err) })
-    .finally(() => consumer.commitOffset({ topic, partition, offset: m.offset }))
+    .then(() => {
+      consumer.commitOffset({ topic, partition, offset: m.offset })
+    })
+    .catch((err) => {
+      logger.logFullError(err)
+      // commit offset regardless of errors
+      consumer.commitOffset({ topic, partition, offset: m.offset })
+    })
 })
 
 /**


### PR DESCRIPTION
This error was caused by calling finally() method on the promise returned by "async" function.
"async" functions return native Promise which cannot be overwritten by "global.Promise = require('bluebird')", see https://github.com/petkaantonov/bluebird/issues/1434 for details.