### PR TITLE
feat: enable phase create/update handlers

### DIFF
--- a/src/services/ProcessorServicePhase.js
+++ b/src/services/ProcessorServicePhase.js
@@ -66,14 +66,8 @@ async function create (message) {
     return _.assign(doc._source, { phases })
   }
 
-  // NOTE Disable indexing phases when create at the moment, as it's now being indexed inside Project Service.
-  //      It's because adding a phase may cause cascading updates of other phases and in such cases we are doing
-  //      one ES index call instead of multiple calls. Otherwise ES may fail with error `version conflict`.
-  //      This would be turned on back, as soon as we get rid of such cascading updates inside Project Service.
-  //
-  // await helper.updateProjectESPromise(message.projectId, updateDocPromise)
-  // logger.debug(`Project phase created successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
-  logger.debug(`TEMPORARY SKIPPED: Project phase created successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
+  await helper.updateProjectESPromise(message.projectId, updateDocPromise)
+  logger.debug(`Project phase created successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
 }
 
 create.schema = {
@@ -97,14 +91,8 @@ async function update (message) {
     return _.assign(doc._source, { phases })
   }
 
-  // NOTE Disable indexing phases when update at the moment, as it's now being indexed inside Project Service.
-  //      It's because updating a phase may cause cascading updates of other phases and in such cases we are doing
-  //      one ES index call instead of multiple calls. Otherwise ES may fail with error `version conflict`.
-  //      This would be turned on back, as soon as we get rid of such cascading updates inside Project Service.
-  //
-  // await helper.updateProjectESPromise(message.projectId, updateDocPromise)
-  // logger.debug(`Project phase updated successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
-  logger.debug(`TEMPORARY SKIPPED: Project phase updated successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
+  await helper.updateProjectESPromise(message.projectId, updateDocPromise)
+  logger.debug(`Project phase updated successfully in elasticsearch index, (projectPhaseId: ${message.id})`)
 }
 
 update.schema = {


### PR DESCRIPTION
Project Service doesn't handle phases indexing anymore after getting rid of RabbitMQ in favor of using Kafka as per https://github.com/topcoder-platform/tc-project-service/issues/584.